### PR TITLE
catch FileNotFoundError when invoking tput

### DIFF
--- a/gitlab_registry_cleanup/cli.py
+++ b/gitlab_registry_cleanup/cli.py
@@ -34,7 +34,7 @@ class CredentialsReadError(Exception):
 def has_terminal_color() -> bool:
     try:
         return os.isatty(sys.stderr.fileno()) and int(subprocess.check_output(['tput', 'colors'])) >= 8
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         return False
 
 


### PR DESCRIPTION
This adds compatibility for windows systems.

Fixes this error:
![image](https://user-images.githubusercontent.com/2536303/40716042-f3519c1e-6407-11e8-80a6-6715316adbf6.png)
