### PR TITLE
readme: use gitlab-ctl registry-garbage-collect

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,5 @@ are still stored on disk. To delete unused image layers, you must run the Docker
 installed the GitLab omnibus package, you can run the following commands:
 
 ```bash
-sudo gitlab-ctl stop registry
-sudo /opt/gitlab/embedded/bin/registry garbage-collect /var/opt/gitlab/registry/config.yml
-sudo gitlab-ctl start registry
+sudo gitlab-ctl registry-garbage-collect
 ```


### PR DESCRIPTION
gitlab-ctl registry-garbage-collect does registry stop by it's own

```

root@soa ~/tracboat# gitlab-ctl registry-garbage-collect
ok: down: registry: 0s, normally up
Running garbage-collect using configuration from /var/opt/gitlab/registry/config.yml, this might take a while...
...
ok: run: registry: (pid 27260) 1s
```